### PR TITLE
Issue #2860334 by steveoliver, olafkarsten: Use array short syntax to…

### DIFF
--- a/modules/local_storage/commerce_stock_local.install
+++ b/modules/local_storage/commerce_stock_local.install
@@ -274,11 +274,11 @@ function commerce_stock_local_install() {
     ])
     ->execute();
 
-  $defaultStockLocation = StockLocation::create(array(
+  $defaultStockLocation = StockLocation::create([
     'name' => 'Main',
     'status' => TRUE,
     'type' => "default",
-  ));
+  ]);
   $defaultStockLocation->save();
 
 }
@@ -287,12 +287,12 @@ function commerce_stock_local_install() {
  * Adds 'entity_type' column to commerce_stock_transaction table.
  */
 function commerce_stock_local_update_8001() {
-  $spec = array(
+  $spec = [
     'description' => 'Purchasable entity type',
     'type'        => 'varchar_ascii',
     'length'      => EntityTypeInterface::ID_MAX_LENGTH,
     'not null'    => FALSE,
-  );
+  ];
   $schema = \Drupal::database()->schema();
   $schema->addField('commerce_stock_transaction', 'entity_type', $spec);
 }

--- a/modules/local_storage/commerce_stock_local.module
+++ b/modules/local_storage/commerce_stock_local.module
@@ -108,9 +108,9 @@ function _commerce_stock_local_update_stock_level_queue() {
  */
 function commerce_stock_local_theme() {
   $theme = [];
-  $theme['commerce_stock_location'] = array(
+  $theme['commerce_stock_location'] = [
     'render element' => 'elements',
-  );
+  ];
   $theme['commerce_stock_location_content_add_list'] = [
     'render element' => 'content',
     'variables' => ['content' => NULL],

--- a/modules/local_storage/src/Entity/StockLocationViewsData.php
+++ b/modules/local_storage/src/Entity/StockLocationViewsData.php
@@ -15,11 +15,11 @@ class StockLocationViewsData extends EntityViewsData {
   public function getViewsData() {
     $data = parent::getViewsData();
 
-    $data['commerce_stock_location']['table']['base'] = array(
+    $data['commerce_stock_location']['table']['base'] = [
       'field' => 'id',
       'title' => $this->t('Commerce stock location'),
       'help' => $this->t('The stock location ID.'),
-    );
+    ];
 
     return $data;
   }

--- a/modules/local_storage/src/LocalStockUninstallValidator.php
+++ b/modules/local_storage/src/LocalStockUninstallValidator.php
@@ -60,13 +60,13 @@ class LocalStockUninstallValidator implements ModuleUninstallValidatorInterface 
             ) {
               $reasons[] = $this->t(
                 '<a href=":url">Remove field values</a>: @field-name on entity type @entity_type.',
-                array(
+                [
                   '@field-name' => $storage_definition->getName(),
                   '@entity_type' => $entity_type->getLabel(),
                   ':url' => Url::fromRoute(
                     'commerce_stock_local.prepare_module_uninstall'
                   )->toString(),
-                )
+                ]
               );
             }
           }

--- a/modules/ui/src/Form/StockTransactions1.php
+++ b/modules/ui/src/Form/StockTransactions1.php
@@ -43,6 +43,14 @@ class StockTransactions1 extends FormBase {
   /**
    * {@inheritdoc}
    */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+    // @todo - We need to check the product has is managed by a stock service.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     // Get the selected product.
     $product_variation_id = $form_state->getValue('product_variation');

--- a/modules/ui/src/Form/StockTransactions1.php
+++ b/modules/ui/src/Form/StockTransactions1.php
@@ -43,14 +43,6 @@ class StockTransactions1 extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-    parent::validateForm($form, $form_state);
-    // @todo - We need to check the product has is managed by a stock service.
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     // Get the selected product.
     $product_variation_id = $form_state->getValue('product_variation');

--- a/modules/ui/src/Form/StockTransactions2.php
+++ b/modules/ui/src/Form/StockTransactions2.php
@@ -162,13 +162,6 @@ class StockTransactions2 extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-    parent::validateForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $transaction_type = $form_state->getValue('transaction_type');
     $product_variation_id = $form_state->getValue('product_variation_id');

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,6 +28,10 @@
   <rule ref="Drupal.Commenting.DocComment.ShortNotCapital">
     <severity>0</severity>
   </rule>
+  <!-- Complains about example code and placeholders for later overriding. -->
+  <rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">
+    <severity>0</severity>
+  </rule>
   <!-- Complains a lot about tests which don't need short descriptions. -->
   <rule ref="Drupal.Commenting.DocComment.MissingShort">
     <severity>0</severity>

--- a/src/Form/StockConfigForm.php
+++ b/src/Form/StockConfigForm.php
@@ -109,13 +109,6 @@ class StockConfigForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-    parent::validateForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $values = $form_state->getValues();
     $config = $this->config('commerce_stock.service_manager');

--- a/tests/src/Functional/ProductAdminTest.php
+++ b/tests/src/Functional/ProductAdminTest.php
@@ -13,6 +13,15 @@ use Drupal\commerce_product\Entity\ProductVariation;
 class ProductAdminTest extends StockBrowserTestBase {
 
   /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'commerce_stock_local',
+  ];
+
+  /**
    * Test the create form.
    */
   public function testCreateProductForm() {


### PR DESCRIPTION
… make the current code sniffer happy

Current version of coding standards/code sniffer complains about array syntax if we not using the short notation. This fixes the errors. I think that fits perfectly in your issue. No need to start another one.